### PR TITLE
Add native tested modules of the Hexagon Toolkit

### DIFF
--- a/library-and-framework-list.json
+++ b/library-and-framework-list.json
@@ -1552,5 +1552,455 @@
         "test_level": "fully-tested"
       }
     ]
+  },
+  {
+    "artifact": "com.hexagonkt:core",
+    "description": "Hexagon core utilities. Includes logging helpers.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [ "https://github.com/hexagonkt/hexagon/tree/master/core/src/main/resources/META-INF/native-image/com.hexagonkt/core" ],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/core/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:handlers",
+    "description": "Handlers to be applied on events processing.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/handlers/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:http",
+    "description": "HTTP classes. These classes are shared among the HTTP client and the HTTP server.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [ "https://github.com/hexagonkt/hexagon/tree/master/http/http/src/main/resources/META-INF/native-image/com.hexagonkt/http" ],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/http/http/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:http_client",
+    "description": "HTTP client supporting SSL, cookies, WebSockets, and HTTP/2. Requires an adapter to be used.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/http/http_client/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:http_client_jetty",
+    "description": "HTTP client adapter for Jetty (without WebSockets support).",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/http/http_client_jetty/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:http_client_jetty_ws",
+    "description": "HTTP client adapter for Jetty (with WebSockets support).",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/http/http_client_jetty_ws/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:http_handlers",
+    "description": "HTTP handlers used to apply many callbacks to HTTP calls.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/http/http_handlers/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:http_server",
+    "description": "HTTP server supporting SSL, cookies, WebSockets, and HTTP/2. Requires an adapter to be used.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/http/http_server/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:http_server_jetty",
+    "description": "HTTP server adapter for Jetty (using Servlets under the hood).",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [ "https://github.com/hexagonkt/hexagon/tree/master/http/http_server_jetty/src/main/resources/META-INF/native-image/com.hexagonkt/http_server_jetty" ],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/http/http_server_jetty/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:http_server_netty",
+    "description": "HTTP server adapter for Netty.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [ "https://github.com/hexagonkt/hexagon/tree/master/http/http_server_netty/src/main/resources/META-INF/native-image/com.hexagonkt/http_server_netty" ],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/http/http_server_netty/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:http_server_netty_epoll",
+    "description": "HTTP server adapter for Netty (using Linux Epoll).",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/http/http_server_netty_epoll/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:http_server_nima",
+    "description": "HTTP server adapter for Helidon Nima (using Java Virtual Threads).",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/http/http_server_nima/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:rest",
+    "description": "HTTP server extensions to ease the development of REST APIs.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/http/rest/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:rest_tools",
+    "description": "Tools to test and document REST services.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/http/rest_tools/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:web",
+    "description": "HTTP server extensions to ease the development of dynamic Web applications.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/http/web/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:logging_jul",
+    "description": "Hexagon Java Util Logging adapter.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/logging/logging_jul/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:logging_logback",
+    "description": "Hexagon Logback logging adapter.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/logging/logging_logback/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:logging_slf4j_jul",
+    "description": "Hexagon SLF4J logging adapter (using JUL as SLF4J engine).",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/logging/logging_slf4j_jul/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:serialization",
+    "description": "Hexagon serialization module.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/serialization/serialization/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:serialization_dsl_json",
+    "description": "Hexagon JSON serialization format (using DSL-JSON).",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/serialization/serialization_dsl_json/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:serialization_jackson",
+    "description": "Jackson's serialization utilities (used in several serialization formats).",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [ "https://github.com/hexagonkt/hexagon/tree/master/serialization/serialization_jackson/src/main/resources/META-INF/native-image/com.hexagonkt/serialization_jackson" ],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/serialization/serialization_jackson/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:serialization_jackson_csv",
+    "description": "Hexagon CSV serialization format (using Jackson).",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/serialization/serialization_jackson_csv/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:serialization_jackson_json",
+    "description": "Hexagon JSON serialization format (using Jackson).",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/serialization/serialization_jackson_json/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:serialization_jackson_toml",
+    "description": "Hexagon TOML serialization format (using Jackson).",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/serialization/serialization_jackson_toml/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:serialization_jackson_xml",
+    "description": "Hexagon XML serialization format (using Jackson).",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/serialization/serialization_jackson_xml/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:serialization_jackson_yaml",
+    "description": "Hexagon YAML serialization format (using Jackson).",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/serialization/serialization_jackson_yaml/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:templates",
+    "description": "Template processing port. Supports template loading and context passing. Allow multiple adapters at once.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/templates/templates/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:templates_freemarker",
+    "description": "Template processor adapter for Freemarker.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/templates/templates_freemarker/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:templates_pebble",
+    "description": "Template processor adapter for Pebble.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/templates/templates_pebble/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
+  },
+  {
+    "artifact": "com.hexagonkt:templates_rocker",
+    "description": "Template processor adapter for Rocker. Don't support dynamic template loading.",
+    "details": [
+      {
+        "minimum_version": "3.0.0",
+        "test_level": "fully-tested",
+        "metadata_locations": [],
+        "tests_locations": [
+          "https://github.com/hexagonkt/hexagon/tree/master/templates/templates_rocker/src/test",
+          "https://github.com/hexagonkt/hexagon/actions/workflows/nightly.yml"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
* Native tests are checked in the nightly build against 'develop' branch
* Not all modules contains native image metadata, in that case, 'metadata_locations' is an empty array

## What does this PR do?
Add native tested modules of the Hexagon Toolkit

## Checklist before merging
- [ ] I have considered including reachability metadata directly in the library or the framework (see [our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md))
- [ ] I am the original author of all content provided in the pull request, and I did not copy the content from any other source (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] For all tests where I am not the sole author, I have added a comment that proves I may publish them under the specified license (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#tests))
- [ ] I have properly formatted metadata files (see [our formatting guide](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#format-metadata-files))
- [ ] I have added thorough tests (see [the tests section from our contributing document](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md#Tests))
- [ ] I have filled all places where my pull request accesses files, network, docker, or any other external service (see the section above)
